### PR TITLE
Added GPIO IRQ interface, refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+## [0.2.1]
+
+### Added
+
+- Adds the IRQ interface to configure interrupts on output and input pins
+- Utility function to set up millisecond timer with `TIM0`
+- Function to set clock divisor registers in `clock` module
+
 ### Changed
 
 - Minor optimizations and tweaks for GPIO module
+- Moved the `FilterClkSel` struct to the `clock` module, re-exporting in `gpio`
+- Clearing output state at initialization of Output pins
 
 ## [0.2.0]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "va108xx-hal"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Robin Mueller <robin.mueller.m@gmail.com>"]
 edition = "2021"
 description = "HAL for the Vorago VA108xx family of microcontrollers"

--- a/examples/timer-ticks.rs
+++ b/examples/timer-ticks.rs
@@ -12,7 +12,7 @@ use va108xx_hal::{
     pac::{self, interrupt},
     prelude::*,
     time::Hertz,
-    timer::{CountDownTimer, Event},
+    timer::{set_up_ms_timer, CountDownTimer, Event},
 };
 
 #[allow(dead_code)]
@@ -65,23 +65,21 @@ fn main() -> ! {
             }
         }
         LibType::Hal => {
-            let mut ms_timer =
-                CountDownTimer::tim0(&mut dp.SYSCONFIG, get_sys_clock().unwrap(), dp.TIM0);
-            let mut second_timer =
-                CountDownTimer::tim1(&mut dp.SYSCONFIG, get_sys_clock().unwrap(), dp.TIM1);
-            ms_timer.listen(
-                Event::TimeOut,
+            set_up_ms_timer(
                 &mut dp.SYSCONFIG,
                 &mut dp.IRQSEL,
+                50.mhz().into(),
+                dp.TIM0,
                 interrupt::OC0,
             );
+            let mut second_timer =
+                CountDownTimer::tim1(&mut dp.SYSCONFIG, get_sys_clock().unwrap(), dp.TIM1);
             second_timer.listen(
                 Event::TimeOut,
                 &mut dp.SYSCONFIG,
                 &mut dp.IRQSEL,
                 interrupt::OC1,
             );
-            ms_timer.start(1000.hz());
             second_timer.start(1.hz());
             unmask_irqs();
         }

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -25,6 +25,18 @@ pub enum PeripheralClocks {
     Gpio = 24,
 }
 
+#[derive(Debug, PartialEq)]
+pub enum FilterClkSel {
+    SysClk = 0,
+    Clk1 = 1,
+    Clk2 = 2,
+    Clk3 = 3,
+    Clk4 = 4,
+    Clk5 = 5,
+    Clk6 = 6,
+    Clk7 = 7,
+}
+
 /// The Vorago in powered by an external clock which might have different frequencies.
 /// The clock can be set here so it can be used by other software components as well.
 /// The clock can be set exactly once
@@ -37,6 +49,19 @@ pub fn set_sys_clock(freq: Hertz) {
 /// Returns the configured system clock
 pub fn get_sys_clock() -> Option<Hertz> {
     interrupt::free(|cs| SYS_CLOCK.borrow(cs).get().copied())
+}
+
+pub fn set_clk_div_register(syscfg: &mut SYSCONFIG, clk_sel: FilterClkSel, div: u32) {
+    match clk_sel {
+        FilterClkSel::SysClk => (),
+        FilterClkSel::Clk1 => syscfg.ioconfig_clkdiv1.write(|w| unsafe { w.bits(div) }),
+        FilterClkSel::Clk2 => syscfg.ioconfig_clkdiv2.write(|w| unsafe { w.bits(div) }),
+        FilterClkSel::Clk3 => syscfg.ioconfig_clkdiv3.write(|w| unsafe { w.bits(div) }),
+        FilterClkSel::Clk4 => syscfg.ioconfig_clkdiv4.write(|w| unsafe { w.bits(div) }),
+        FilterClkSel::Clk5 => syscfg.ioconfig_clkdiv5.write(|w| unsafe { w.bits(div) }),
+        FilterClkSel::Clk6 => syscfg.ioconfig_clkdiv6.write(|w| unsafe { w.bits(div) }),
+        FilterClkSel::Clk7 => syscfg.ioconfig_clkdiv7.write(|w| unsafe { w.bits(div) }),
+    }
 }
 
 pub fn enable_peripheral_clock(syscfg: &mut SYSCONFIG, clock: PeripheralClocks) {

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -5,7 +5,10 @@
 //! - [MS and second tick implementation](https://github.com/robamu-org/va108xx-hal-rs/blob/main/examples/timer-ticks.rs)
 use crate::{
     clock::{enable_peripheral_clock, PeripheralClocks},
+    pac,
+    prelude::*,
     time::Hertz,
+    timer,
 };
 use embedded_hal::timer::{Cancel, CountDown, Periodic};
 use va108xx::{Interrupt, IRQSEL, SYSCONFIG};
@@ -158,6 +161,20 @@ macro_rules! timers {
             }
         )+
     }
+}
+
+// Set up a millisecond timer on TIM0. Please note that you still need to unmask the related IRQ
+// and provide an IRQ handler yourself
+pub fn set_up_ms_timer(
+    syscfg: &mut pac::SYSCONFIG,
+    irqsel: &mut pac::IRQSEL,
+    sys_clk: Hertz,
+    tim0: TIM0,
+    irq: pac::Interrupt,
+) {
+    let mut ms_timer = CountDownTimer::tim0(syscfg, sys_clk, tim0);
+    ms_timer.listen(timer::Event::TimeOut, syscfg, irqsel, irq);
+    ms_timer.start(1000.hz());
 }
 
 timers! {

--- a/src/uart.rs
+++ b/src/uart.rs
@@ -1,6 +1,7 @@
 //! # API for the UART peripheral
 //!
 //! ## Examples
+//!
 //! - [UART example](https://github.com/robamu-org/va108xx-hal-rs/blob/main/examples/uart.rs)
 use core::{convert::Infallible, ptr};
 use core::{marker::PhantomData, ops::Deref};


### PR DESCRIPTION
- Adds the IRQ interface to configure interrupts on output and input pins
- Moved the `FilterClkSel` struct to the `clock` module, reexporting in `gpio`
- Added function to set clock divisor registers
- Clearing output state at initialization of Output pins
- Added utility function to set up millisecond timer with `TIM0`