### PR TITLE
Clock passing and SPI Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - DelayUs and DelayMs trait implementations for timer
 - SPI implementation for blocking API, supports blockmode as well
 
+### Changed
+
+- API which expects values in Hertz now uses `impl Into<Hertz>` as input parameter
+
 ## [0.2.1]
 
 ### Added

--- a/examples/spi.rs
+++ b/examples/spi.rs
@@ -62,10 +62,10 @@ fn main() -> ! {
                 pinsa.pa29.into_funsel_1(),
             );
             spia_ref.borrow_mut().replace(
-                Spi::spia::<NoneT>(
+                Spi::spia(
                     dp.SPIA,
                     (sck, miso, mosi),
-                    50.mhz().into(),
+                    50.mhz(),
                     spi_cfg,
                     Some(&mut dp.SYSCONFIG),
                     None,
@@ -80,10 +80,10 @@ fn main() -> ! {
                 pinsb.pb7.into_funsel_2(),
             );
             spia_ref.borrow_mut().replace(
-                Spi::spia::<NoneT>(
+                Spi::spia(
                     dp.SPIA,
                     (sck, miso, mosi),
-                    50.mhz().into(),
+                    50.mhz(),
                     spi_cfg,
                     Some(&mut dp.SYSCONFIG),
                     None,
@@ -98,10 +98,10 @@ fn main() -> ! {
                 pinsb.pb3.into_funsel_1(),
             );
             spib_ref.borrow_mut().replace(
-                Spi::spib::<NoneT>(
+                Spi::spib(
                     dp.SPIB,
                     (sck, miso, mosi),
-                    50.mhz().into(),
+                    50.mhz(),
                     spi_cfg,
                     Some(&mut dp.SYSCONFIG),
                     None,
@@ -114,10 +114,9 @@ fn main() -> ! {
     match SPI_BUS_SEL {
         SpiBusSelect::SpiAPortA | SpiBusSelect::SpiAPortB => {
             if let Some(ref mut spi) = *spia_ref.borrow_mut() {
-                let transfer_cfg = TransferConfig::<NoneT>::new(
+                let transfer_cfg = TransferConfig::new_no_hw_cs(
                     SPI_SPEED_KHZ.khz().into(),
                     SPI_MODE,
-                    None,
                     BLOCKMODE,
                     false,
                 );

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -40,9 +40,9 @@ pub enum FilterClkSel {
 /// The Vorago in powered by an external clock which might have different frequencies.
 /// The clock can be set here so it can be used by other software components as well.
 /// The clock can be set exactly once
-pub fn set_sys_clock(freq: Hertz) {
+pub fn set_sys_clock(freq: impl Into<Hertz>) {
     interrupt::free(|cs| {
-        SYS_CLOCK.borrow(cs).set(freq).ok();
+        SYS_CLOCK.borrow(cs).set(freq.into()).ok();
     })
 }
 

--- a/src/uart.rs
+++ b/src/uart.rs
@@ -46,7 +46,7 @@ pub enum Error {
     BreakCondition,
 }
 
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 pub enum Event {
     // Receiver FIFO interrupt enable. Generates interrupt
     // when FIFO is at least half full. Half full is defined as FIFO


### PR DESCRIPTION
1. Using `impl Into<Hertz>` instead of Hertz now to increase usability for users
2. Update for SPI API to increase usability